### PR TITLE
Add Japanese translation

### DIFF
--- a/index.html
+++ b/index.html
@@ -191,6 +191,7 @@
 			<option value="ca">Català</option>
 			<option value="ptb">Português Brasileiro</option>
 			<option value="ru">Russian</option>
+			<option value="ja">日本語</option>
 		</select>
 	</div>
 

--- a/js/RomPatcher.js
+++ b/js/RomPatcher.js
@@ -183,6 +183,8 @@ function setLanguage(langCode){
 
 	userLanguage=LOCALIZATION[langCode];
 
+	document.documentElement.lang = langCode;
+
 	var translatableElements=document.querySelectorAll('*[data-localize]');
 	for(var i=0; i<translatableElements.length; i++){
 		translatableElements[i].innerHTML=_(translatableElements[i].dataset.localize);

--- a/js/locale.js
+++ b/js/locale.js
@@ -160,5 +160,32 @@ const LOCALIZATION={
 		'error_unzipping':			'Erro ao extrair arquivo',
 		'error_invalid_patch':		'Patch inválido',
 		'warning_too_big':			'Uso de arquivos muito grandes não recomendado.'
+	},
+	'ja':{
+		'creator_mode':				'作成モード',
+
+		'apply_patch':				'パッチを当て',
+		'rom_file':					'ROMファィル：',
+		'patch_file':				'パッチファイル：',
+		'remove_header':			'ヘッダーを削除',
+		'add_header':				'一時的なヘッダーを追加',
+		'compatible_formats':		'互換性のあるフォーマット：',
+		'applying_patch':			'パッチを当ている…',
+		'downloading':				'ダウンロードしている…',
+		'unzipping':				'解凍している…',
+
+		'create_patch':				'パッチを作成',
+		'original_rom':				'元のROM：',
+		'modified_rom':				'変更されたROM：',
+		'patch_type':				'パッチのタイプ：',
+		'creating_patch':			'パッチを作成している…',
+
+		'error_crc_input':			'ソースROMチェックサムの不一致',
+		'error_crc_output':			'ターゲットROMチェクサムの不一致',
+		'error_crc_patch':			'バッチチェックサムの不一致',
+		'error_downloading':		'パッチのダウンロードエラー',
+		'error_unzipping':			'パッチの解凍エラー',
+		'error_invalid_patch':		'無効なパッチエラー',
+		'warning_too_big':			'大きなファイルの使いはおすすめしない。'
 	}
 };


### PR DESCRIPTION
This simply adds a Japanese translation as I saw this was translatable and I know enough Japanese to translate it so I did 😄

Tested on my MacBook Air in Japanese running locally and everything looked to work correctly.

---

Update: I also added setting the document language on language change so that you don't have the wrong form of characters shown, mostly relevant for Chinese characters since Unicode unifies all of the languages, but there are some differences in fonts.

Ex: "日本語" (Japanese) in Japanese font:
![スクリーンショット 2021-03-08 0 47 35](https://user-images.githubusercontent.com/41608708/110284888-0c264500-7fa8-11eb-8c34-5ef59521d50e.png)
and Chinese font:
![スクリーンショット 2021-03-08 0 47 28](https://user-images.githubusercontent.com/41608708/110284898-0fb9cc00-7fa8-11eb-98da-be568f7f624c.png)

This would usually be gotten correctly assuming your computer's language was set correctly, but this just makes certain it's right, such as if a Japanese user uses a Windows computer in English, it'll use Chinese forms, which while far from unreadable looks a bit bad, and there's no downsides to setting the document language correctly.