### PR TITLE
Fix: UPS patch's cut glitch

### DIFF
--- a/js/formats/ups.js
+++ b/js/formats/ups.js
@@ -57,6 +57,11 @@ UPS.prototype.apply=function(romFile, validate){
 		throw new Error('error_crc_input');
 	}
 
+	/* fix the glitch that cut the end of the file if it's larger than the changed file patch was originally created with */
+	sizeOutput = this.sizeOutput
+	if(!validate && sizeOutput < this.sizeInput){
+		sizeOutput = this.sizeInput
+	}
 
 	/* copy original file */
 	tempFile=new MarcFile(this.sizeOutput);

--- a/js/formats/ups.js
+++ b/js/formats/ups.js
@@ -59,13 +59,17 @@ UPS.prototype.apply=function(romFile, validate){
 
 	/* fix the glitch that cut the end of the file if it's larger than the changed file patch was originally created with */
 	sizeOutput = this.sizeOutput
-	if(!validate && sizeOutput < this.sizeInput){
-		sizeOutput = this.sizeInput
+	sizeInput = this.sizeInput
+	if(!validate && sizeInput < romFile.fileSize){
+		sizeInput = romFile.fileSize
+		if(sizeOutput < sizeInput){
+			sizeOutput = sizeInput
+		}
 	}
 
 	/* copy original file */
 	tempFile=new MarcFile(sizeOutput);
-	romFile.copyToFile(tempFile, 0, this.sizeInput);
+	romFile.copyToFile(tempFile, 0, sizeInput);
 
 	romFile.seek(0);
 

--- a/js/formats/ups.js
+++ b/js/formats/ups.js
@@ -64,7 +64,7 @@ UPS.prototype.apply=function(romFile, validate){
 	}
 
 	/* copy original file */
-	tempFile=new MarcFile(this.sizeOutput);
+	tempFile=new MarcFile(sizeOutput);
 	romFile.copyToFile(tempFile, 0, this.sizeInput);
 
 	romFile.seek(0);


### PR DESCRIPTION
Fix the glitch that cut the end of the file if it's larger than the changed file patch was originally created with like [NUPS](https://www.romhacking.net/utilities/606/) does, because many patch creators are using it to create UPS patches, and they won't apply correctly without this fix. It also fixes mismatching results with NUPS in the same filesize.