### PR TITLE
BUG FIX: Prevent truncation when the patched file is larger than the original.

### DIFF
--- a/js/MarcFile.js
+++ b/js/MarcFile.js
@@ -102,7 +102,8 @@ MarcFile.prototype.slice=function(offset, len){
 	if(typeof this._u8array.buffer.slice!=='undefined'){
 		newFile=new MarcFile(0);
 		newFile.fileSize=len;
-		newFile._u8array=new Uint8Array(this._u8array.buffer.slice(offset, offset+len));
+		newFile._u8array=new Uint8Array(len);
+		newFile._u8array.set(new Uint8Array(this._u8array.buffer.slice(offset, offset+len)));
 	}else{
 		newFile=new MarcFile(len);
 		this.copyToFile(newFile, offset, len, 0);


### PR DESCRIPTION
Hello!

Over at the HTGDB we [noticed some unexpected behavior](https://github.com/frederic-mahe/Hardware-Target-Game-Database/issues/777) when the patched rom's file size is larger than the original. In our case we were trying to apply [this patch](https://www.romhacking.net/hacks/4873/) to a 128KB rom which should give us a 512KB rom, but it was actually truncating the patched rom to the first 128KB.

I haven't tested this fix very thoroughly but it seems to work (that is, it gives me the same output as Lunar IPS, Flips, etc.). But I've only spent a few minutes grokking this code so please don't assume that I know what I'm doing.

