### PR TITLE
[fix] `rec` can be undefined in `IPS.prototype.export`

### DIFF
--- a/js/formats/ips.js
+++ b/js/formats/ips.js
@@ -63,7 +63,7 @@ IPS.prototype.export=function(fileName){
 	}
 
 	tempFile.writeString('EOF');
-	if(rec.truncate)
+	if(rec && rec.truncate)
 		tempFile.writeU24(rec.truncate);
 
 

--- a/js/formats/ips.js
+++ b/js/formats/ips.js
@@ -63,8 +63,8 @@ IPS.prototype.export=function(fileName){
 	}
 
 	tempFile.writeString('EOF');
-	if(rec && rec.truncate)
-		tempFile.writeU24(rec.truncate);
+	if(this.truncate)
+		tempFile.writeU24(this.truncate);
 
 
 	return tempFile


### PR DESCRIPTION
this PR fix the error in browser console:
```
Uncaught TypeError: Cannot read properties of undefined (reading 'truncate')
    at IPS.export (ips.js:66:9)
    at self.onmessage (worker_create.js:48:31)
```