### PR TITLE
File input accept arguments on iOS must be mime types, not file extenions

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@
 			<div class="row m-b" id="rom-patcher-row-file-patch">
 				<div class="text-right"><label for="rom-patcher-input-file-patch" data-localize="yes">Patch file:</label></div>
 				<div class="rom-patcher-container-input">
-					<input type="file" id="rom-patcher-input-file-patch" class="empty" accept=".ips,.ups,.bps,.aps,.rup,.ppf,.mod,.xdelta,.vcdiff,.zip" disabled />
+					<input type="file" id="rom-patcher-input-file-patch" class="empty" accept=".ips,.ups,.bps,.aps,.rup,.ppf,.mod,.xdelta,.vcdiff,.zip,application/octet-stream" disabled />
 				</div>
 			</div>
 			<div class="row m-b" id="rom-patcher-row-patch-description">

--- a/rom-patcher-js/RomPatcher.webapp.js
+++ b/rom-patcher-js/RomPatcher.webapp.js
@@ -35,7 +35,7 @@
 	- switch to ES6 classes and modules?
 */
 
-const ROM_PATCHER_JS_PATH = 'https://xenophile127.github.io/RomPatcher.js/rom-patcher-js/';
+const ROM_PATCHER_JS_PATH = './rom-patcher-js/';
 
 const RomPatcherWeb = (function () {
 	const SCRIPT_DEPENDENCIES = [

--- a/rom-patcher-js/RomPatcher.webapp.js
+++ b/rom-patcher-js/RomPatcher.webapp.js
@@ -35,7 +35,7 @@
 	- switch to ES6 classes and modules?
 */
 
-const ROM_PATCHER_JS_PATH = './rom-patcher-js/';
+const ROM_PATCHER_JS_PATH = 'https://xenophile127.github.io/RomPatcher.js/rom-patcher-js/';
 
 var RomPatcherWeb = (function () {
 	const SCRIPT_DEPENDENCIES = [


### PR DESCRIPTION
Fixes issue #80: Some iOS devices don't allow chosing patch files.