### PR TITLE
Support for EBP format

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
 <head>
 	<title>Rom Patcher JS</title>
 	<meta http-equiv="content-Type" content="text/html; charset=UTF-8"/>
-	<meta name="description" content="An online web-based ROM patcher. Supported formats: IPS, BPS, UPS, APS, RUP, PPF and xdelta."/>
-	<meta name="keywords" content="ips,ups,aps,bps,rup,ninja,ppf,xdelta,patcher,online,html5,web,rom,patch,hack,translation"/>
+	<meta name="description" content="An online web-based ROM patcher. Supported formats: IPS, BPS, UPS, APS, RUP, PPF, EBP and xdelta."/>
+	<meta name="keywords" content="ips,ebp,ups,aps,bps,rup,ninja,ppf,xdelta,patcher,online,html5,web,rom,patch,hack,translation"/>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0"/>
 	<link rel="manifest" href="./manifest.json"/>
 	<link rel="shortcut icon" href="./webapp/app_icon_16.png" type="image/png" sizes="16x16"/>
@@ -27,7 +27,7 @@
 	<meta name="twitter:domain" content="marcrobledo.com">
 	<meta property="og:title" content="Rom Patcher JS">
 	<meta name="twitter:title" content="Rom Patcher JS">
-	<meta name="twitter:description" content="An online web-based ROM patcher. Supported formats: IPS, BPS, UPS, APS, RUP, PPF and xdelta.">
+	<meta name="twitter:description" content="An online web-based ROM patcher. Supported formats: IPS, BPS, UPS, APS, RUP, PPF, EBP and xdelta.">
 	<meta property="og:image" content="https://www.marcrobledo.com/RomPatcher.js/webapp/thumbnail.jpg">
 	<meta name="twitter:image" content="https://www.marcrobledo.com/RomPatcher.js/webapp/thumbnail.jpg">
 	<meta name="twitter:card" content="photo">
@@ -83,7 +83,7 @@
 			<div class="row m-b" id="rom-patcher-row-file-patch">
 				<div class="text-right"><label for="rom-patcher-input-file-patch" data-localize="yes">Patch file:</label></div>
 				<div class="rom-patcher-container-input">
-					<input type="file" id="rom-patcher-input-file-patch" class="empty" accept=".ips,.ups,.bps,.aps,.rup,.ppf,.mod,.xdelta,.vcdiff,.zip" disabled />
+					<input type="file" id="rom-patcher-input-file-patch" class="empty" accept=".ips,.ups,.bps,.aps,.rup,.ppf,.mod,.ebp,.xdelta,.vcdiff,.zip" disabled />
 				</div>
 			</div>
 			<div class="row m-b" id="rom-patcher-row-patch-description">
@@ -126,6 +126,7 @@
 						<option value="ups">UPS</option>
 						<option value="aps">APS</option>
 						<option value="rup">RUP</option>
+						<option value="ebp">EBP</option>
 					</select>
 				</div>
 			</div>

--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ program
     .description('creates a patch based on two ROMs')
     .argument('<original_rom_file>', 'the original ROM')
     .argument('<modified_rom_file>','the modified ROM')
-    .option('-f, --format <format>','patch format (allowed values: ips [default], bps, ppf, ups, aps, rup)')
+    .option('-f, --format <format>','patch format (allowed values: ips [default], bps, ppf, ups, aps, rup, ebp)')
     .action(function(originalRomPath, modifiedRomPath, options) {
 		console.log(options);
 		try{

--- a/rom-patcher-js/RomPatcher.js
+++ b/rom-patcher-js/RomPatcher.js
@@ -242,8 +242,8 @@ const RomPatcher = (function () {
 				format = 'ips';
 
 			var patch;
-			if (format === 'ips') {
-				patch = IPS.buildFromRoms(originalFile, modifiedFile);
+			if (format === 'ips' || format === 'ebp') {
+				patch = IPS.buildFromRoms(originalFile, modifiedFile, format === 'ebp');
 			} else if (format === 'bps') {
 				patch = BPS.buildFromRoms(originalFile, modifiedFile, (originalFile.fileSize <= 4194304));
 			} else if (format === 'ppf') {

--- a/rom-patcher-js/RomPatcher.webapp.js
+++ b/rom-patcher-js/RomPatcher.webapp.js
@@ -1175,7 +1175,7 @@ const ZIPManager = (function (romPatcherWeb) {
 
 	const ZIP_MAGIC = '\x50\x4b\x03\x04';
 
-	const FILTER_PATCHES = /\.(ips|ups|bps|aps|rup|ppf|mod|xdelta|vcdiff)$/i;
+	const FILTER_PATCHES = /\.(ips|ebp|ups|bps|aps|rup|ppf|mod|xdelta|vcdiff)$/i;
 	//const FILTER_ROMS=/(?<!\.(txt|diz|rtf|docx?|xlsx?|html?|pdf|jpe?g|gif|png|bmp|webp|zip|rar|7z))$/i; //negative lookbehind is not compatible with Safari https://stackoverflow.com/a/51568859
 	const FILTER_NON_ROMS = /(\.(txt|diz|rtf|docx?|xlsx?|html?|pdf|jpe?g|gif|png|bmp|webp|zip|rar|7z))$/i;
 

--- a/rom-patcher-js/modules/RomPatcher.format.ips.js
+++ b/rom-patcher-js/modules/RomPatcher.format.ips.js
@@ -13,7 +13,9 @@ const IPS_RECORD_SIMPLE=0x01;
 /* When creating patches, insert this data after everything else. */
 /* Finally, EBP doesn't seem to support truncation metadata. */
 const EBP_MAGIC_META_OPENER = 0x7B //UTF-8 '{'
-const EBP_META_DEFAULT={"author": "Unknown", "title": "Untitled", "description": "No description"}
+/* EBPatcher (linked above) expects the "patcher" field to be EBPatcher to read the metadata. Can't imagine why... */
+/* CoilSnake (EB modding tool) inserts this manually too. */
+const EBP_META_DEFAULT={"patcher": "EBPatcher", "author": "Unknown", "title": "Untitled", "description": "No description"}
 
 if(typeof module !== "undefined" && module.exports){
 	module.exports = IPS;
@@ -34,7 +36,7 @@ IPS.prototype.addRLERecord=function(o, l, b){
 }
 IPS.prototype.addEBPMetadata=function(author, title, description){
 	/* currently not used - no frontend support */
-	this.EBPmetadata=JSON.stringify({"author": author, "title": title, "description": description})
+	this.EBPmetadata=JSON.stringify({"patcher": "EBPatcher", "author": author, "title": title, "description": description})
 }
 IPS.prototype.toString=function(){
 	nSimpleRecords=0;

--- a/test.js
+++ b/test.js
@@ -14,6 +14,9 @@
 	- IPS test
 		- Patch: https://www.romhacking.net/hacks/3784/
 		- ROM:   Super Mario Land 2 - 6 Golden Coins (USA, Europe).gb [CRC32=d5ec24e4]
+	- EBP test
+		- Patch: https://forum.starmen.net/forum/Community/PKHack/NickBound/page/1#post2333521
+		- ROM:   EarthBound (USA).sfc [CRC32=dc9bb451]
 	- BPS test
 		- Patch: https://www.romhacking.net/translations/6297/
 		- ROM:   Samurai Kid (Japan).gbc [CRC32=44a9ddfb]	
@@ -50,6 +53,14 @@ const TEST_PATCHES = [
 		patchCrc32: 0x0b742316,
 		patchDownload: 'https://www.romhacking.net/hacks/3784/',
 		outputCrc32: 0xf0799017
+	}, {
+		title: 'EBP - Mother Rebound',
+		romFile: 'EarthBound (USA).sfc',
+		romCrc32: 0xdc9bb451,
+		patchFile: 'Mother_Rebound.ebp',
+		patchCrc32: 0x271719e1,
+		patchDownload: 'https://forum.starmen.net/forum/Community/PKHack/NickBound/page/1#post2333521',
+		outputCrc32: 0x5065b02f
 	}, {
 		title: 'BPS - Samurai Kid translation',
 		romFile: 'Samurai Kid (Japan).gbc',


### PR DESCRIPTION
EBP (EarthBound Patch) is a format based on IPS which is commonly used to distribute hacks of EarthBound. It's actually just IPS with some JSON metadata tacked on the end. Personally I don't like the format, but it's still in use and this closes #30.

The implementation does not add an entirely new format module. Instead, the IPS module will change its behaviour slightly if the patch is detected as (when applying) or specified to be (when creating) an EBP format patch.