### PR TITLE
Adding docker setup to run multiple patches on a single rom in a docker container

### DIFF
--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,8 +1,0 @@
-# Ignore everything by default
-# **
-
-# But include minimal needed files/folders
-!rom-patcher-js/modules/
-!rom-patcher-js/RomPatcher.js
-!index.js
-!package.json

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,0 +1,8 @@
+# Ignore everything by default
+# **
+
+# But include minimal needed files/folders
+!rom-patcher-js/modules/
+!rom-patcher-js/RomPatcher.js
+!index.js
+!package.json

--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,0 +1,2 @@
+/input
+/output

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,10 @@ RUN apt-get update && apt-get install -y unzip && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 
 # Copy everything from project root EXCEPT docker/ (using .dockerignore)
-COPY . .
+COPY rom-patcher-js/modules ./rom-patcher-js/modules
+COPY rom-patcher-js/RomPatcher.js ./rom-patcher-js/RomPatcher.js
+COPY index.js ./index.js
+COPY package.json ./package.json
 RUN npm install
 
 # Explicitly copy entrypoint.sh from docker folder into root of container

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:lts-slim
+
+# Install unzip
+RUN apt-get update && apt-get install -y unzip && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy everything from project root EXCEPT docker/ (using .dockerignore)
+COPY . .
+RUN npm install
+
+# Explicitly copy entrypoint.sh from docker folder into root of container
+COPY docker/entrypoint.sh ./entrypoint.sh
+RUN chmod +x ./entrypoint.sh
+
+# Volumes for input/output (host-mapped)
+VOLUME ["/app/input", "/app/output"]
+
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/docker/Readme.md
+++ b/docker/Readme.md
@@ -1,0 +1,57 @@
+# 📄 Docker Setup for RomPatcher.js
+
+## Overview
+
+This Docker setup allows you to patch ROM files using RomPatcher.js inside a container.  
+- Input ROMs and patch files go in the `docker/input` folder.  
+- Patched ROMs are saved to `docker/output`.  
+- ZIP patch files are automatically extracted if needed.
+
+Everything runs inside a Node.js container; no Node installation is required on your host.
+
+---
+
+## Folder Structure
+
+```
+project-root/
+└── docker/
+  ├── .gitignore # Exclude input/output folder content
+  ├── .dockerignore # Exclude unnecessary files from image build
+  ├── docker-compose.yml # Docker Compose setup
+  ├── Dockerfile # Docker image definition
+  ├── entrypoint.sh # Script that applies patches
+  ├── input/ # ROMs + patches (mounted as volume)
+  └── output/ # Patched ROMs (mounted as volume)
+```
+
+- `docker/input` and `docker/output` are **volumes** - files here are visible on the host.  
+
+---
+
+## Docker Build & Run
+
+### Build & Run the image
+
+From inside the `docker/` folder:
+
+```bash
+docker-compose up --build
+```
+
+- Patches all ROMs in `docker/input`.
+
+- Output files are saved to `docker/output`.
+
+## Example Usage
+
+1. Put `MyGame.v64` in `docker/input`.
+
+2. Put patches (`*.bps` or `*.zip`) in `docker/input`.
+
+3. Build and run:
+```bash
+cd docker
+docker-compose up --build
+```
+4. Patched ROMs appear in `docker/output`

--- a/docker/Readme.md
+++ b/docker/Readme.md
@@ -1,4 +1,4 @@
-# 📄 Docker Setup for RomPatcher.js
+# Docker Setup for RomPatcher.js
 
 ## Overview
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  rompatcher:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    container_name: rompatcher
+    volumes:
+      - ./input:/app/input
+      - ./output:/app/output
+    restart: "no"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -53,8 +53,8 @@ for patch in "$TEMP_PATCHES"/*/* "$TEMP_PATCHES"/*; do
     echo "Applying patch: $PATCH_BASE → $ROM_FILE"
     node "$RP_DIR/index.js" patch "$ROM_FILE" "$patch"
 
-    result=$(ls *.v64 | head -n 1)
-    echo "Copying patched ROM $result to $OUTPUT_FILE"
+    result=$(ls *.$ROM_EXT | head -n 1)
+    echo "Moving patched ROM $result to $OUTPUT_FILE"
     mv "$result" "$OUTPUT_FILE"
 done
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -32,7 +32,7 @@ for z in "$INPUT_DIR"/*.zip; do
     else
         echo "Extracting ZIP patch: $z → $TARGET_DIR"
         mkdir -p "$TARGET_DIR"
-        unzip -o "$z" -d "$TARGET_DIR"
+        unzip -o "$z" -d "$TARGET_DIR" -x "*.txt"
     fi
 done
 
@@ -50,8 +50,12 @@ for patch in "$TEMP_PATCHES"/*/* "$TEMP_PATCHES"/*; do
     PATCH_NAME="${PATCH_BASE%.*}"
     OUTPUT_FILE="$OUTPUT_DIR/$PATCH_NAME.$ROM_EXT"
 
-    echo "Applying patch: $PATCH_BASE → $OUTPUT_FILE"
-    node "$RP_DIR/index.js" patch "$ROM_FILE" "$patch" "$OUTPUT_FILE"
+    echo "Applying patch: $PATCH_BASE → $ROM_FILE"
+    node "$RP_DIR/index.js" patch "$ROM_FILE" "$patch"
+
+    result=$(ls *.v64 | head -n 1)
+    echo "Copying patched ROM $result to $OUTPUT_FILE"
+    mv "$result" "$OUTPUT_FILE"
 done
 
 echo "All patches applied. Output files are in $OUTPUT_DIR"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+set -e
+
+# Directories inside container
+INPUT_DIR="/app/input"
+OUTPUT_DIR="/app/output"
+TEMP_PATCHES="/tmp/patches"
+RP_DIR="/app"
+
+mkdir -p "$TEMP_PATCHES" "$OUTPUT_DIR"
+
+# Detect ROM (first non-patch file)
+ROM_FILE=$(find "$INPUT_DIR" -maxdepth 1 -type f ! -iname "*.zip" ! -iname "*.bps" ! -iname "*.ips" ! -iname "*.ups" ! -iname "*.ppf" ! -iname "*.xdelta" | head -n 1)
+
+if [ -z "$ROM_FILE" ]; then
+    echo "ERROR: No ROM found in $INPUT_DIR"
+    exit 1
+fi
+
+ROM_NAME=$(basename "$ROM_FILE")
+ROM_EXT="${ROM_NAME##*.}"
+echo "ROM detected: $ROM_NAME"
+
+# Extract ZIP patches if not already extracted
+for z in "$INPUT_DIR"/*.zip; do
+    [ -e "$z" ] || continue
+    ZIP_BASENAME=$(basename "$z" .zip)
+    TARGET_DIR="$TEMP_PATCHES/$ZIP_BASENAME"
+
+    if [ -d "$TARGET_DIR" ] && [ "$(ls -A "$TARGET_DIR")" ]; then
+        echo "ZIP patch already extracted: $z"
+    else
+        echo "Extracting ZIP patch: $z → $TARGET_DIR"
+        mkdir -p "$TARGET_DIR"
+        unzip -o "$z" -d "$TARGET_DIR"
+    fi
+done
+
+# Copy individual patch files (bps, ips, ups, ppf, xdelta) into TEMP_PATCHES
+find "$INPUT_DIR" -maxdepth 1 -type f \( -iname "*.bps" -o -iname "*.ips" -o -iname "*.ups" -o -iname "*.ppf" -o -iname "*.xdelta" \) \
+    -exec cp {} "$TEMP_PATCHES" \;
+
+# Apply each patch
+for patch in "$TEMP_PATCHES"/*/* "$TEMP_PATCHES"/*; do
+    [ -e "$patch" ] || continue
+    # skip directories without patches
+    [ -f "$patch" ] || continue
+
+    PATCH_BASE=$(basename "$patch")
+    PATCH_NAME="${PATCH_BASE%.*}"
+    OUTPUT_FILE="$OUTPUT_DIR/$PATCH_NAME.$ROM_EXT"
+
+    echo "Applying patch: $PATCH_BASE → $OUTPUT_FILE"
+    node "$RP_DIR/index.js" patch "$ROM_FILE" "$patch" "$OUTPUT_FILE"
+done
+
+echo "All patches applied. Output files are in $OUTPUT_DIR"


### PR DESCRIPTION
Got an Analogue 3d recently and saw a ton of cool SM64 rom hacks. Probably spent more time building this than it would have taken to patch them all, but oh well. Here it is.

This pull request adds a Docker-based workflow for patching ROMs using RomPatcher.js. The changes include:

- A Dockerfile and docker-compose configuration to run RomPatcher.js in a container.
- An `entrypoint.sh` script that:
  - Creates `input` and `output` directories if they do not exist.
  - Automatically extracts ZIP patch files if necessary.
  - Applies multiple BPS patches to ROMs in the input directory and outputs them to the output directory, naming the output files based on the patch name.
- Volume mounts for `input` and `output` to persist data between the host and container.
- README updates with instructions for building and running the container using `docker-compose up --build`.

These changes allow users to patch ROMs in a reproducible environment without requiring Node.js or RomPatcher.js installed locally, and ensure commits and patches are isolated from the host filesystem.