### PR TITLE
Fix some rare edge cases in IPS patching

### DIFF
--- a/rom-patcher-js/modules/RomPatcher.format.ips.js
+++ b/rom-patcher-js/modules/RomPatcher.format.ips.js
@@ -173,11 +173,15 @@ IPS.fromFile=function(file){
 			}else if((file.offset+3)===file.fileSize){
 				patchFile.truncate=file.readU24();
 				break;
-			}else if (file.readU8()==='{'.charCodeAt(0)) {
-				file.skip(-1);
+			}
+
+			const nextByte=file.readU8();
+			file.skip(-1);
+			if(nextByte==='{'.charCodeAt(0)){
 				patchFile.setEBPMetadata(JSON.parse(file.readString(file.fileSize-file.offset)));
 				break;
 			}
+			// 0x454F46 is a legitimate record offset, keep iterating
 		}
 
 		var length=file.readU16();

--- a/rom-patcher-js/modules/RomPatcher.format.ips.js
+++ b/rom-patcher-js/modules/RomPatcher.format.ips.js
@@ -175,13 +175,22 @@ IPS.fromFile=function(file){
 				break;
 			}
 
+			const savedOffset=file.offset;
 			const nextByte=file.readU8();
-			file.skip(-1);
 			if(nextByte==='{'.charCodeAt(0)){
-				patchFile.setEBPMetadata(JSON.parse(file.readString(file.fileSize-file.offset)));
-				break;
+				file.skip(-1);
+				let metadata=null;
+				try{
+					metadata=JSON.parse(file.readString(file.fileSize-file.offset));
+				}catch{}
+				if(metadata!==null){
+					patchFile.setEBPMetadata(metadata);
+					break;
+				}
 			}
-			// 0x454F46 is a legitimate record offset, keep iterating
+			// 0x454F46 is the actual offset of a record,
+			// seek back and continue to read it normally
+			file.seek(savedOffset)
 		}
 
 		var length=file.readU16();

--- a/test.js
+++ b/test.js
@@ -167,7 +167,6 @@ const MODIFIED_TEST_DATA = (new Uint8Array([
 		const originalFile = new BinFile(TEST_DATA);
 		const modifiedFile = new BinFile(MODIFIED_TEST_DATA);
 		const patch = RomPatcher.createPatch(originalFile, modifiedFile, patchFormat);
-		const patchedFile = RomPatcher.applyPatch(originalFile, patch, { requireValidation: true });
 
 		if (patchFormat === 'bps') {
 			if (patch.patchChecksum !== patch.calculateFileChecksum())
@@ -176,8 +175,15 @@ const MODIFIED_TEST_DATA = (new Uint8Array([
 				throw new Error('invalid BPS crc32');
 		}
 
+		const patchedFile = RomPatcher.applyPatch(originalFile, patch, { requireValidation: true });
 		if (patchedFile.hashCRC32() !== modifiedFile.hashCRC32())
 			throw new Error('modified and patched files\' crc32 do not match');
+
+		const roundtrippedPatch = RomPatcher.parsePatchFile(patch.export('test.' + patchFormat));
+		const roundtrippedPatchedFile = RomPatcher.applyPatch(originalFile, roundtrippedPatch, { requireValidation: true });
+
+		if (roundtrippedPatchedFile.hashCRC32() !== modifiedFile.hashCRC32())
+			throw new Error('modified and patched files\' crc32 do not match after exporting/importing patch file');
 	})
 });
 
@@ -223,3 +229,39 @@ TEST_PATCHES.forEach(function (patchInfo) {
 });
 
 
+/*
+	Test an IPS patch that modifies data at address 0x454F46, which is "EOF" in ASCII
+	This is the same byte sequence as the IPS end of file marker.
+*/
+_test('IPS - patch record at EOF address (0x454F46)', function () {
+	const fileSize = 0x454F46 + 1;
+	const originalFile = new BinFile((new Uint8Array(fileSize)).buffer);
+	const modifiedFile = new BinFile(function() {
+		let b = new Uint8Array(fileSize);
+		b[fileSize-1] = 255;
+		return b.buffer
+	}());
+
+	// create and apply patch
+	const patch = RomPatcher.createPatch(originalFile, modifiedFile, 'ips');
+	const patchedFile = RomPatcher.applyPatch(originalFile, patch);
+	if (patchedFile.hashCRC32() !== modifiedFile.hashCRC32())
+		throw new Error('modified and patched files\' crc32 do not match');
+
+	// roundtrip the patch through export/import before applying
+	const exportedPatch = patch.export('test.ips');
+	const expectedBytes = [
+		80, 65, 84, 67, 72, // "PATCH"
+		69, 79, 70,         // address 0x454F46 ("EOF" -> looks like the eof marker)
+		0, 1,               // length 1
+		255,                // the data
+		69, 79, 70          // "EOF"
+	];
+	if (exportedPatch.fileSize !== expectedBytes.length || expectedBytes.some((b, i) => exportedPatch._u8array[i] !== b))
+		throw new Error('exported patch bytes do not match expected');
+
+	const roundtrippedPatch = RomPatcher.parsePatchFile(exportedPatch);
+	const roundtrippedPatchedFile = RomPatcher.applyPatch(originalFile, roundtrippedPatch);
+	if (roundtrippedPatchedFile.hashCRC32() !== modifiedFile.hashCRC32())
+		throw new Error('modified and patched files\' crc32 do not match after exporting/importing patch file');
+});

--- a/test.js
+++ b/test.js
@@ -230,15 +230,17 @@ TEST_PATCHES.forEach(function (patchInfo) {
 
 
 /*
-	Test an IPS patch that modifies data at address 0x454F46, which is "EOF" in ASCII
-	This is the same byte sequence as the IPS end of file marker.
+	Test an IPS patch that modifies 31488 bytes starting at 0x454F46.
+	This results in the sequence "EOF{" in the patch file which is the
+	same sequence as the IPS end-of-file marker with some extra EBP metadata.
 */
-_test('IPS - patch record at EOF address (0x454F46)', function () {
-	const fileSize = 0x454F46 + 1;
+_test('IPS - test patching 31488 bytes at address 0x454F46 ("EOF{")', function () {
+	const fileSize = 0x454F46 + 31488;
 	const originalFile = new BinFile((new Uint8Array(fileSize)).buffer);
 	const modifiedFile = new BinFile(function() {
 		let b = new Uint8Array(fileSize);
-		b[fileSize-1] = 255;
+		b.fill(255, 0x454F46);
+		b[fileSize-1] = 254;  // make data non-uniform to avoid producing a RLE record
 		return b.buffer
 	}());
 
@@ -253,11 +255,9 @@ _test('IPS - patch record at EOF address (0x454F46)', function () {
 	const expectedBytes = [
 		80, 65, 84, 67, 72, // "PATCH"
 		69, 79, 70,         // address 0x454F46 ("EOF" -> looks like the eof marker)
-		0, 1,               // length 1
-		255,                // the data
-		69, 79, 70          // "EOF"
+		123, 0,             // length 31488 (0x7B00 -> "{\x00" -> looks like EBP metadata)
 	];
-	if (exportedPatch.fileSize !== expectedBytes.length || expectedBytes.some((b, i) => exportedPatch._u8array[i] !== b))
+	if (expectedBytes.some((b, i) => exportedPatch._u8array[i] !== b))
 		throw new Error('exported patch bytes do not match expected');
 
 	const roundtrippedPatch = RomPatcher.parsePatchFile(exportedPatch);


### PR DESCRIPTION
IPS patches end with the bytes `EOF`. In cases where an IPS patch defines a record with the offset of `0x454F46` (`EOF` in ascii), this offset would be misread as the end-of-file marker and the rest of the file would be ignored.

This PR fixes this by updating the IPS patch parsing logic to peek forward at the rest of the file to determine if the `0x454F46` it's seeing is actually the end-of-file marker or is just an address. A test was also added to verify the behavior is correct.

Also, since the issue only appeared when exporting and importing the patch file, I updated the existing tests to roundtrip the patch data through their respective binary formats as well.