### PR TITLE
reuse already defined variable

### DIFF
--- a/rom-patcher-js/RomPatcher.webapp.js
+++ b/rom-patcher-js/RomPatcher.webapp.js
@@ -501,7 +501,7 @@ const RomPatcherWeb = (function () {
 				}
 			}
 			if (!scriptPath)
-				scriptPath = './rom-patcher-js/';
+				scriptPath = ROM_PATCHER_JS_PATH;
 		}
 		return scriptPath.substring(0, scriptPath.lastIndexOf('/') + 1);
 	}


### PR DESCRIPTION
something I noticed while adjusting `ROM_PATCHER_JS_PATH` variable due to relative path troubles.

replaces hardcoded path with already defined constant variable of same path.

Line 38:
`const ROM_PATCHER_JS_PATH = './rom-patcher-js/';`

Line 504:
`scriptPath = './rom-patcher-js/';`